### PR TITLE
fix: was not defaulting output to input

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ try {
   if (argv["dry-run"]) {
     console.log(input);
   } else {
-    const output = argv.output === false ? argv.input : argv.output;
+    const output = argv.output ? argv.output : argv.input;
 
     fs.writeFile(output, input, error => {
       if (error) {


### PR DESCRIPTION
not sure this is the best approach, but it was not working for me when i used only input, as in the documentation.  got 'path must be a string', since argv.output was never false - rather undefined.  this fixes the problem for me.  node 5.12.0