### PR TITLE
Do not emit trailing newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ try {
   const input = yaml.safeDump(doc, { sortKeys: true });
 
   if (argv["dry-run"]) {
-    console.log(input);
+    process.stdout.write(input);
   } else {
     const output = argv.output ? argv.output : argv.input;
 


### PR DESCRIPTION
Call `process.stdout.write` instead of `console.log` to avoid additional
newline.