### PR TITLE
Fix errore -> error

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ try {
 
     fs.writeFile(output, input, error => {
       if (error) {
-        return console.error(errore);
+        return console.error(error);
       }
     });
   }


### PR DESCRIPTION
Simple fix for:

```
yml-sorter/index.js:61
        return console.error(errore);
                             ^

ReferenceError: errore is not defined
```
